### PR TITLE
biometrics: Allow posting reset runnable for all clients

### DIFF
--- a/core/res/res/values/potato_config.xml
+++ b/core/res/res/values/potato_config.xml
@@ -31,4 +31,8 @@
     <!-- Whether to cleanup fingerprints upon connection to the daemon and when user switches -->
     <bool name="config_cleanupUnusedFingerprints">true</bool>
 
+    <!-- Whether to post reset runnable for all clients. Needed for some older
+         vendor fingerprint HAL implementations. -->
+    <bool name="config_fingerprintPostResetRunnableForAllClients">false</bool>
+
 </resources>

--- a/core/res/res/values/potato_symbols.xml
+++ b/core/res/res/values/potato_symbols.xml
@@ -26,4 +26,7 @@
   <!-- Whether to cleanup fingerprints upon connection to the daemon and when user switches -->
   <java-symbol type="bool" name="config_cleanupUnusedFingerprints" />
 
+  <!-- Post reset runnable for all clients -->
+  <java-symbol type="bool" name="config_fingerprintPostResetRunnableForAllClients" />
+
 </resources>

--- a/services/core/java/com/android/server/biometrics/BiometricServiceBase.java
+++ b/services/core/java/com/android/server/biometrics/BiometricServiceBase.java
@@ -92,6 +92,7 @@ public abstract class BiometricServiceBase extends SystemService
     private final ResetClientStateRunnable mResetClientState = new ResetClientStateRunnable();
     private final ArrayList<LockoutResetMonitor> mLockoutMonitors = new ArrayList<>();
     private final boolean mCleanupUnusedFingerprints;
+    private final boolean mPostResetRunnableForAllClients;
 
     protected final IStatusBarService mStatusBarService;
     protected final Map<Integer, Long> mAuthenticatorIds =
@@ -662,6 +663,8 @@ public abstract class BiometricServiceBase extends SystemService
         mMetricsLogger = new MetricsLogger();
         mCleanupUnusedFingerprints = mContext.getResources().getBoolean(
                 com.android.internal.R.bool.config_cleanupUnusedFingerprints);
+        mPostResetRunnableForAllClients = mContext.getResources().getBoolean(
+                com.android.internal.R.bool.config_fingerprintPostResetRunnableForAllClients);
     }
 
     @Override
@@ -1069,6 +1072,10 @@ public abstract class BiometricServiceBase extends SystemService
                             + newClient.getClass().getSuperclass().getSimpleName()
                             + "(" + newClient.getOwnerString() + ")"
                             + ", initiatedByClient = " + initiatedByClient);
+                }
+                if (mPostResetRunnableForAllClients) {
+                    mHandler.removeCallbacks(mResetClientState);
+                    mHandler.postDelayed(mResetClientState, CANCEL_TIMEOUT_LIMIT);
                 }
             } else {
                 currentClient.stop(initiatedByClient);


### PR DESCRIPTION
 * After commit df755c8, some devices fail to enumerate for
   unknown reason (likely a HAL issue). Add an overlay to
   restore old behavior and thus workaround this issue.

Change-Id: Ib0d00d5987aa7f68a5c7efa785859e8eb208651d